### PR TITLE
add --nodeps for rpmbuild

### DIFF
--- a/Makefile.rpm
+++ b/Makefile.rpm
@@ -8,8 +8,8 @@ auto-apps-$(VERSION).tar.gz:
 
 srpm: auto-apps-$(VERSION).tar.gz auto-apps.spec.in
 	sed s/@@VERSION@@/$(VERSION)/g auto-apps.spec.in > auto-apps.spec
-	rpmbuild -bs --define "_srcrpmdir $(TOPDIR)"  --define "_sourcedir $(TOPDIR)" auto-apps.spec
+	rpmbuild -bs --nodeps --define "_srcrpmdir $(TOPDIR)"  --define "_sourcedir $(TOPDIR)" auto-apps.spec
 
 rpm: auto-apps-$(VERSION).tar.gz auto-apps.spec.in
 	sed s/@@VERSION@@/$(VERSION)/g auto-apps.spec.in > auto-apps.spec
-	rpmbuild -ba --define "_srcrpmdir $(TOPDIR)"  --define "_sourcedir $(TOPDIR)" auto-apps.spec
+	rpmbuild -ba --nodeps --define "_srcrpmdir $(TOPDIR)"  --define "_sourcedir $(TOPDIR)" auto-apps.spec


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the RPM package build process to build packages without enforcing dependency checks, offering a more flexible packaging workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->