### PR TITLE
    Add generalize image for developers

### DIFF
--- a/dev-image.aib.yml
+++ b/dev-image.aib.yml
@@ -97,6 +97,9 @@ content:
       - tkn-install.service
       - oc-install.service
       - jumpstarter-setup.service
+      
+image:
+  image_size: 20 GiB
 
 auth:
   root_password: $6$xoLqEUz0cGGJRx01$H3H/bFm0myJPULNMtbSsOFd/2BnHqHkMD92Sfxd.EKM9hXTWSmELG8cf205l6dktomuTcgKGGtGDgtvHVXSWU.

--- a/dev-image.aib.yml
+++ b/dev-image.aib.yml
@@ -1,0 +1,114 @@
+name: dev-image
+
+content: 
+  rpms:
+    - vim
+    - git
+    - openssl
+    - make
+    - cmake
+    - gdb
+    - gcc
+    - gcc-c++
+    - glibc-devel
+    - libffi-devel 
+    - libstdc++-devel 
+    - zlib-devel
+    - kernel-headers
+    - libcurl-devel
+    - openssh-server
+    - dnf
+    - tar
+    - osbuild
+    - python3.12
+    - python3.12-pip
+    - podman
+    - automotive-image-builder
+
+  add_files:
+    - path: /oc-arm64-rhel9.tar.gz
+      url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.18/openshift-client-linux-arm64-rhel9.tar.gz
+    
+    - path: /tkn.rpm
+      url: https://github.com/tektoncd/cli/releases/download/v0.40.0/tektoncd-cli-0.40.0_Linux-ARM64.rpm
+
+    - path: /usr/local/bin/caib
+      url: https://github.com/rh-sdv-cloud-incubator/automotive-dev-operator/releases/download/v0.0.7/caib-v0.0.7-arm64
+
+    - path: /usr/lib/systemd/system/tkn-install.service
+      text: |
+        [Unit]
+        Description=Extract Tekton CLI tarball
+        After=network-online.target
+        ConditionPathExists=/tkn.rpm
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/dnf install -y /tkn.rpm
+        RemainAfterExit=true
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - path: /usr/lib/systemd/system/oc-install.service
+      text: |
+        [Unit]
+        Description=Download and extract OpenShift CLI (oc + kubectl)
+        After=network-online.target
+        ConditionPathExists=/oc-arm64-rhel9.tar.gz
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/tar -xzf /oc-arm64-rhel9.tar.gz -C /usr/local/bin
+        ExecStartPost=/usr/bin/chmod +x /usr/local/bin/oc /usr/local/bin/kubectl
+        RemainAfterExit=true
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - path: /usr/lib/systemd/system/caib-install.service
+      text: |
+        [Unit]
+        Description=Make caib executable
+        After=network-online.target
+        ConditionPathExists=/caib
+
+        [Service]
+        Type=oneshot
+        ExecStartPost=/usr/bin/chmod +x /usr/local/bin/caib
+        RemainAfterExit=true
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - path: /setup-jumpstarter.sh
+      text: |
+        #!/bin/bash
+
+        set -e
+        pip3.12 install --extra-index-url https://pkg.jumpstarter.dev/simple jumpstarter-all
+
+    - path: /usr/lib/systemd/system/jumpstarter-setup.service
+      text: |
+        [Unit]
+        Description=Setup Jumpstarter Python Environment
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/chmod +x /setup-jumpstarter.sh
+        ExecStartPost=/setup-jumpstarter.sh
+        RemainAfterExit=true
+
+        [Install]
+        WantedBy=multi-user.target
+
+  systemd:
+    enabled_services:
+      - tkn-install.service
+      - oc-install.service
+      - jumpstarter-setup.service
+      - caib-install.service
+
+auth:
+  root_password: $6$xoLqEUz0cGGJRx01$H3H/bFm0myJPULNMtbSsOFd/2BnHqHkMD92Sfxd.EKM9hXTWSmELG8cf205l6dktomuTcgKGGtGDgtvHVXSWU.

--- a/dev-image.aib.yml
+++ b/dev-image.aib.yml
@@ -66,21 +66,6 @@ content:
         [Install]
         WantedBy=multi-user.target
 
-    - path: /usr/lib/systemd/system/caib-install.service
-      text: |
-        [Unit]
-        Description=Make caib executable
-        After=network-online.target
-        ConditionPathExists=/caib
-
-        [Service]
-        Type=oneshot
-        ExecStartPost=/usr/bin/chmod +x /usr/local/bin/caib
-        RemainAfterExit=true
-
-        [Install]
-        WantedBy=multi-user.target
-
     - path: /setup-jumpstarter.sh
       text: |
         #!/bin/bash
@@ -102,13 +87,16 @@ content:
 
         [Install]
         WantedBy=multi-user.target
+  
+  chmod_files:
+    - path: /usr/local/bin/caib
+      mode: "0755"
 
   systemd:
     enabled_services:
       - tkn-install.service
       - oc-install.service
       - jumpstarter-setup.service
-      - caib-install.service
 
 auth:
   root_password: $6$xoLqEUz0cGGJRx01$H3H/bFm0myJPULNMtbSsOFd/2BnHqHkMD92Sfxd.EKM9hXTWSmELG8cf205l6dktomuTcgKGGtGDgtvHVXSWU.


### PR DESCRIPTION
Add a generalized autosd image for developers with all necessary tools like oc, tkn, aib, caib and jumpstarter, and c/c++ development tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new development environment image configuration with pre-installed tools, libraries, and automation scripts for streamlined setup.
  - Automated installation and setup of essential development utilities, Python environment, and command-line tools.
  - Enabled system services to ensure tools and environments are ready on startup.
  - Configured authentication settings for the development image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->