### PR TITLE
remove workingDirectory

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -29,55 +29,46 @@ commands:
       exec:
           component: runtime
           commandLine: make -f Makefile.dev build-container
-          workingDir: ${PROJECT_SOURCE}
 
     - id: build-app
       exec:
           component: runtime
           commandLine: make -f Makefile.dev build-app
-          workingDir: ${PROJECT_SOURCE}
 
     - id: clean
       exec:
           component: runtime
           commandLine: make -f Makefile.dev clean
-          workingDir: ${PROJECT_SOURCE}
 
     - id: set-app-image
       exec:
           component: runtime
           commandLine: make -f Makefile.dev set-app-image
-          workingDir: ${PROJECT_SOURCE}
 
     - id: build-image-ti
       exec:
           component: runtime
           commandLine: make -f Makefile.dev build-image-ti
-          workingDir: ${PROJECT_SOURCE}
 
     - id: flash-image
       exec:
           component: runtime
           commandLine: make -f Makefile.dev flash-image
-          workingDir: ${PROJECT_SOURCE}
 
     - id: test-sample-apps
       exec:
           component: runtime
           commandLine: make -f Makefile.dev test-sample-apps
-          workingDir: ${PROJECT_SOURCE}
 
     - id: publish-image-reg
       exec:
           component: runtime
           commandLine: make -f Makefile.dev publish-image-reg
-          workingDir: ${PROJECT_SOURCE}
 
     - id: deploy-changes
       exec:
           component: runtime
           commandLine: make -f Makefile.dev deploy-changes
-          workingDir: ${PROJECT_SOURCE}
           group:
               kind: run
               isDefault: false
@@ -86,7 +77,6 @@ commands:
       exec:
           component: runtime
           commandLine: make -f Makefile.dev build-all
-          workingDir: ${PROJECT_SOURCE}
           group:
               kind: build
               isDefault: true


### PR DESCRIPTION
it's set from aib-devspaces, not really following the EC2 config when different

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development environment configuration to use default working directories for various commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->